### PR TITLE
allow separator overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@
 ```js
 postcss([ require('postcss-bem')({
     defaultNamespace: undefined, // default namespace to use, none by default
-    style: 'suit' // suit or bem, suit by default
+    style: 'suit', // suit or bem, suit by default,
+    separators: {
+        descendent: '__' // overwrite any default separator for chosen style
+    }
 }) ])
 ```
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,19 @@ module.exports = postcss.plugin('postcss-bem', function (opts) {
 
     var currentConfig = config[opts.style];
 
+    if (opts.separators) {
+        for (var separator in opts.separators) {
+            if (!opts.separators.hasOwnProperty(separator)) continue;
+
+            var separatorValue = opts.separators[separator];
+            if (typeof separatorValue === 'string') {
+                currentConfig.separators[separator] = separatorValue;
+            } else {
+                throw new Error('postcss-bem: opts.separators.' + separator + ' must be a string');
+            }
+        }
+    }
+
     function processComponent (component, namespace) {
         var name = component.params;
 

--- a/index.js
+++ b/index.js
@@ -31,14 +31,14 @@ module.exports = postcss.plugin('postcss-bem', function (opts) {
     var currentConfig = config[opts.style];
 
     if (opts.separators) {
-        for (var separator in opts.separators) {
-            if (!opts.separators.hasOwnProperty(separator)) continue;
+        for (var customSeparator in opts.separators) {
+            if (!opts.separators.hasOwnProperty(customSeparator)) continue;
 
-            var separatorValue = opts.separators[separator];
+            var separatorValue = opts.separators[customSeparator];
             if (typeof separatorValue === 'string') {
-                currentConfig.separators[separator] = separatorValue;
+                currentConfig.separators[customSeparator] = separatorValue;
             } else {
-                throw new Error('postcss-bem: opts.separators.' + separator + ' must be a string');
+                throw new Error('postcss-bem: opts.separators.' + customSeparator + ' must be a string');
             }
         }
     }


### PR DESCRIPTION
Not sure if it was considered or not, but it would be nice to be able to customize separators.  That way we can write more traditional BEM modifiers that are separated by '--' as opposed to '_'.

Example:
```javascript
require('postcss-bem')({
  style: 'bem',
  separators: {
    modifier: '--'
  }
});
```