### PR TITLE
Shortcuts for keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@
 }
 ```
 
+**With shortcuts**
+```css
+@b nav { /* b is for block */
+    @e item { /* e is for element */
+        display: inline-block;
+    }
+    @m placement_header {
+        background-color: red;
+    }
+}
+```
+
+```css
+.nav {}
+.nav__item {
+    display: inline-block
+}
+.nav_placement_header {
+    background-color: red
+}
+```
+
 ## Usage
 
 ```js
@@ -76,6 +98,9 @@ postcss([ require('postcss-bem')({
     style: 'suit', // suit or bem, suit by default,
     separators: {
         descendent: '__' // overwrite any default separator for chosen style
+    },
+    shortcuts: {
+        utility: 'util' //override at-rule name
     }
 }) ])
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,16 +1,27 @@
 var gulp = require('gulp');
+var watchMode = false;
 
 gulp.task('lint', function () {
     var eslint = require('gulp-eslint');
-    return gulp.src(['index.js', 'test/*.js', 'gulpfile.js'])
+    var stream = gulp.src(['index.js', 'test/*.js', 'gulpfile.js'])
         .pipe(eslint())
-        .pipe(eslint.format())
-        .pipe(eslint.failAfterError());
+        .pipe(eslint.format());
+    if(!watchMode){
+        return stream.pipe(eslint.failAfterError());
+    }else{
+        return stream;
+    }
 });
 
 gulp.task('test', function () {
     var mocha = require('gulp-mocha');
     return gulp.src('test/*.js', { read: false }).pipe(mocha());
+});
+
+
+gulp.task('watch', function () {
+    watchMode = true;
+    return gulp.watch(['index.js', 'test/*.js'], ['lint', 'test']);
 });
 
 gulp.task('default', ['lint', 'test']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ gulp.task('test', function () {
 
 gulp.task('watch', function () {
     watchMode = true;
-    return gulp.watch(['index.js', 'test/*.js'], ['lint', 'test']);
+    return gulp.watch(['index.js', 'test/*.js', 'test/fixtures/*.*'], ['lint', 'test']);
 });
 
 gulp.task('default', ['lint', 'test']);

--- a/test/fixtures/shortcuts.bem.css
+++ b/test/fixtures/shortcuts.bem.css
@@ -1,0 +1,8 @@
+@b nav {
+    @e item {
+        display: inline-block;
+    }
+    @m placement_header {
+        background-color: red;
+    }
+}

--- a/test/fixtures/shortcuts.bem.expected.css
+++ b/test/fixtures/shortcuts.bem.expected.css
@@ -1,0 +1,7 @@
+.nav {}
+.nav__item {
+    display: inline-block
+}
+.nav_placement_header {
+    background-color: red
+}

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,24 @@ function test (input, output, opts, done) {
     });
 }
 
+function testSame(input1, input2, opts, done) {
+    var asyncResults  = [
+        process(input1, opts),
+        process(input2, opts)
+    ];
+    Promise
+        .all(asyncResults)
+        .then(function (results) {
+            expect(results[0].css).to.eql(results[1].css);
+            expect(results[0].warnings()).to.be.empty;
+            expect(results[1].warnings()).to.be.empty;
+            done();
+        })
+        .catch(function (error) {
+            done(error);
+        });
+}
+
 function testWarnings (input, output, warnings, opts, done) {
     process(input, opts).then(function (result) {
         var occuredWarnings = result.warnings();
@@ -267,6 +285,83 @@ describe('postcss-bem', function () {
         describe('@when', function() {
             it('does nothing', function (done) {
                 test('@component component-name {@when stateName {}}', '.component-name {\n    @when stateName {}\n}', useBem, done);
+            });
+        });
+    });
+
+    describe('shortcuts', function () {
+        var useBem = {
+            shortcuts: {
+                'component-namespace': 'ns',
+                component: 'b',
+                modifier: 'm',
+                descendent: 'e'
+            },
+            style: 'bem'
+        };
+        var useSuit = {
+            shortcuts: {
+                utility: 'ut',
+                'component-namespace': 'ns',
+                component: 'com',
+                modifier: 'mod',
+                descendent: 'dec',
+                when: 'state'
+            }
+        };
+
+        describe('bem', function() {
+            it('shortcut for component behaves the same way as component', function (done) {
+                testSame(
+                    '@component component-name {@descendent descendent-name {}}',
+                    '@b component-name {@descendent descendent-name {}}', useBem, done);
+            });
+            it('shortcut for namespace behaves the same way as namespace', function (done) {
+                testSame(
+                    '@component-namespace nmsp {@component component-name {color: red; text-align: right;}}',
+                    '@ns nmsp {@component component-name {color: red; text-align: right;}}', useBem, done);
+            });
+            it('shortcut for descendent behaves the same way as descendent', function (done) {
+                testSame(
+                    '@component component-name {@descendent descendent-name {}}',
+                    '@component component-name {@e descendent-name {}}', useBem, done);
+            });
+            it('shortcut for modifier behaves the same way as modifier', function (done) {
+                testSame(
+                    '@component component-name {@modifier modifier-name {}}',
+                    '@component component-name {@m modifier-name {}}', useBem, done);
+            });
+        });
+        describe('suit', function() {
+            it('shortcut for component behaves the same way as component', function (done) {
+                testSame(
+                    '@component component-name {@descendent descendent-name {}}',
+                    '@com component-name {@descendent descendent-name {}}', useSuit, done);
+            });
+            it('shortcut for utility behaves the same way as utility', function (done) {
+                testSame(
+                    '@utility utilityName {}',
+                    '@ut utilityName {}', useSuit, done);
+            });
+            it('shortcut for namespace behaves the same way as namespace', function (done) {
+                testSame(
+                    '@component-namespace nmsp {@component ComponentName {color: red; text-align: right;}}',
+                    '@ns nmsp {@component ComponentName {color: red; text-align: right;}}', useSuit, done);
+            });
+            it('shortcut for modifier behaves the same way as modifier', function (done) {
+                testSame(
+                    '@component component-name {@modifier modifier-name {}}',
+                    '@component component-name {@mod modifier-name {}}', useSuit, done);
+            });
+            it('shortcut for descendent behaves the same way as descendent', function (done) {
+                testSame(
+                    '@component component-name {@descendent descendent-name {}}',
+                    '@component component-name {@dec descendent-name {}}', useSuit, done);
+            });
+            it('shortcut for @when behaves the same way as @when', function (done) {
+                testSame(
+                    '@component ComponentName {@when stateName {}}',
+                    '@component ComponentName {@state stateName {}}', useSuit, done);
             });
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var postcss = require('postcss');
 var expect  = require('chai').expect;
+var fs = require('fs');
 
 var plugin = require('../');
 
@@ -15,6 +16,11 @@ function test (input, output, opts, done) {
     }).catch(function (error) {
         done(error);
     });
+}
+
+function f(name) {
+    var fullName = './test/fixtures/' + name + '.css';
+    return fs.readFileSync(fullName, 'utf8').trim();
 }
 
 function testSame(input1, input2, opts, done) {
@@ -330,6 +336,14 @@ describe('postcss-bem', function () {
                 testSame(
                     '@component component-name {@modifier modifier-name {}}',
                     '@component component-name {@m modifier-name {}}', useBem, done);
+            });
+            it('shortcut for modifier behaves the same way as modifier', function (done) {
+                testSame(
+                    '@component component-name {color: red; text-align: right; @modifier modifier-name {color: blue; text-align: left;}}',
+                    '@component component-name {color: red; text-align: right; @m modifier-name {color: blue; text-align: left;}}', useBem, done);
+            });
+            it('is beatiful', function(done){
+                test(f('shortcuts.bem'), f('shortcuts.bem.expected'), useBem, done);
             });
         });
         describe('suit', function() {


### PR DESCRIPTION
Your plugin is great! 
For more convenient usage some users would like to use their own naming.

For example it would be nice to name descendents as elements if U use bem. Or use 1 letter shortening to create more compact code.

```css
@b nav { /* b is for block */
    @e item { /* e is for element */
        display: inline-block;
    }
    @m placement_header {
        background-color: red;
    }
}
```
  