### PR TITLE
Upgrade to postcss 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url":  "https://github.com/ileri/postcss-bem.git"
     },
     "dependencies": {
-        "postcss": "^4.1.9"
+        "postcss": "^5.0.8"
     },
     "devDependencies": {
         "gulp-eslint": "^0.12.0",


### PR DESCRIPTION
Upgraded to postcss 5 as the plugin produces output with lacking attributes when used in a postcss-5 chain.

Actual output (in a v5 chain using postcss-v4 dependency):
```
...
@component ComponentName { /* .ComponentName */
    test1: 42424;
    test2: 24242;

    @modifier modifierName { /* .ComponentName--modifierName */
    }

    @descendent descendentName { /* .ComponentName-descendentName */
    }

}
...
```

Expected output:
```
...
@component ComponentName { /* .ComponentName */
    test1: 42424;
    test2: 24242;

    @modifier modifierName { /* .ComponentName--modifierName */
        test3: 42442;
        test4: r2525;
    }

    @descendent descendentName { /* .ComponentName-descendentName */
        trt: twetze;
        teasta: tataw;
    }
}
...
```